### PR TITLE
Update setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fix incremental composite keys ([#144](https://github.com/dbeatty10/dbt-mysql/issues/144))
+- Fix UnicodeDecodeErorr on setup.py ([#160](https://github.com/dbeatty10/dbt-mysql/issues/160))
 
 ### Contributors
 - [@lpezet](https://github.com/lpezet) ([#146](https://github.com/dbeatty10/dbt-mysql/pull/146), [#144](https://github.com/dbeatty10/dbt-mysql/issues/144))

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     name="dbt-mysql",
     version=_plugin_version(),
     description="The MySQL adapter plugin for dbt",
-    long_description=README.read_text(),
+    long_description=README.read_text(encoding='utf-8'),
     long_description_content_type="text/markdown",
     author="Doug Beatty",
     author_email="doug.beatty@gmail.com",


### PR DESCRIPTION
Explicitly defining utf-8 encoding to avoid UnicodeDecodeError on setup.py in Windows environment

resolves #

Resolves #160


### Description
Changes long_description=README.read_text() to long_description=README.read_text(encoding='utf-8')
in setup.py


### Checklist
 - [X ] I have run this code in development and it appears to resolve the stated issue
 - [X ] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
